### PR TITLE
Add initial version of the VMSS module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+.terraform.lock.hcl
+local.tfvars

--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
 # Spacelift Worker for Azure
 
 Terraform module for deploying a Spacelift worker pool on Azure using a VMSS.
+
+## Usage
+
+NOTE: please make sure you [accept the terms](#accepting-terms) for our Azure Marketplace
+image before trying to use the module.
+
+```hcl
+module "azure-worker" {
+  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool"
+
+  admin_password = "Super Secret Password!"
+
+  configuration = <<-EOT
+    export SPACELIFT_TOKEN="${var.worker_pool_config}"
+    export SPACELIFT_POOL_PRIVATE_KEY="${var.worker_pool_private_key}"
+  EOT
+
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.subnet_id
+  worker_pool_id      = var.worker_pool_id
+}
+```
+
+## Accepting Terms
+
+Before you can use our Marketplace image, you need to accept the terms and conditions for the
+image for the subscription you want to deploy the image to. You can do this using the following
+command:
+
+```shell
+az vm image terms accept \
+  --publisher "spaceliftinc1625499025476" \
+  --offer "spacelift_worker" \
+  --plan "ubuntu_20_04"
+```
+
+More information can be found [here](https://go.microsoft.com/fwlink/?linkid=2110637).

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,127 @@
+variable "admin_password" {
+  type        = string
+  default     = null
+  description = "The admin password for the scale set. Either admin_password or admin_public_key must be set."
+}
+
+variable "admin_public_key" {
+  type        = string
+  description = "The base64 encoded public key. Either admin_public_key or admin_password must be set."
+  default     = null
+}
+
+variable "admin_username" {
+  type        = string
+  description = "The admin username for the scale set."
+  default     = "spacelift"
+}
+
+variable "application_security_group_ids" {
+  type        = list(string)
+  description = "Any Application Security Groups to tag the VM NICs with."
+  default     = null
+}
+
+variable "configuration" {
+  type        = string
+  description = "Allows custom configuration to be performed as part of the startup script."
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Top-level domain name to use for pulling the launcher binary."
+  default     = "spacelift.io"
+}
+
+variable "identity_ids" {
+  type        = list(string)
+  description = "The list of user-assigned identities to associate with the VM instances."
+  default     = null
+}
+
+variable "identity_type" {
+  type        = string
+  description = "The type of identity to associate with the VM instances."
+  default     = null
+}
+
+variable "name_prefix" {
+  type    = string
+  default = "sp5ft"
+}
+
+variable "overprovision" {
+  type        = bool
+  description = "Indicates whether to allow Azure to overprovision the number of VM replicas when adding VMs."
+  default     = true
+}
+
+variable "resource_group" {
+  type = object({
+    name     = string
+    location = string
+  })
+  description = "The resource group to deploy the scale set to."
+}
+
+variable "source_image_id" {
+  type        = string
+  description = "The VM image to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
+  default     = null
+}
+
+variable "source_image_publisher" {
+  type        = string
+  description = "The image publisher to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
+  default     = "spaceliftinc1625499025476"
+}
+
+variable "source_image_offer" {
+  type        = string
+  description = "The image offer to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
+  default     = "spacelift_worker"
+}
+
+variable "source_image_sku" {
+  type        = string
+  description = "The image SKU to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
+  default     = "ubuntu_20_04"
+}
+
+variable "source_image_version" {
+  type        = string
+  description = "The image version to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
+  default     = "latest"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "The ID of the Azure subnet to place the VMs in."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Any tags to add to the resources this module creates."
+  default     = {}
+}
+
+variable "vmss_instances" {
+  type        = number
+  description = "The number of VM instances to create."
+  default     = 2
+}
+
+variable "vmss_sku" {
+  type        = string
+  description = "The VM SKU to use for the VMSS instances."
+  default     = "Standard_B2S"
+}
+
+variable "worker_pool_id" {
+  type        = string
+  description = "The ID of the Spacelift worker pool."
+}
+
+locals {
+  namespace = "${var.name_prefix}-${var.worker_pool_id}"
+}

--- a/vmss.tf
+++ b/vmss.tf
@@ -1,0 +1,151 @@
+locals {
+  worker_script_head = <<EOF
+#!/bin/bash
+spacelift () {(
+set -e
+  EOF
+
+  worker_script_tail = <<EOF
+echo "Updating packages" >> /var/log/spacelift/info.log
+unattended-upgrade -d 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+
+echo "Downloading Spacelift launcher" >> /var/log/spacelift/info.log
+curl https://downloads.${var.domain_name}/spacelift-launcher --output /usr/bin/spacelift-launcher 2>>/var/log/spacelift/error.log
+echo "Importing public GPG key" >> /var/log/spacelift/info.log
+curl https://keys.openpgp.org/vks/v1/by-fingerprint/175FD97AD2358EFE02832978E302FB5AA29D88F7 | gpg --import 2>>/var/log/spacelift/error.log
+echo "Downloading Spacelift launcher checksum file and signature" >> /var/log/spacelift/info.log
+curl https://downloads.${var.domain_name}/spacelift-launcher_SHA256SUMS --output spacelift-launcher_SHA256SUMS 2>>/var/log/spacelift/error.log
+curl https://downloads.${var.domain_name}/spacelift-launcher_SHA256SUMS.sig --output spacelift-launcher_SHA256SUMS.sig 2>>/var/log/spacelift/error.log
+echo "Verifying checksum signature..." >> /var/log/spacelift/info.log
+gpg --verify spacelift-launcher_SHA256SUMS.sig 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+retStatus=$?
+if [ $retStatus -eq 0 ]; then
+    echo "OK\!" >> /var/log/spacelift/info.log
+else
+    return $retStatus
+fi
+CHECKSUM=$(cut -f 1 -d ' ' spacelift-launcher_SHA256SUMS)
+rm spacelift-launcher_SHA256SUMS spacelift-launcher_SHA256SUMS.sig
+LAUNCHER_SHA=$(sha256sum /usr/bin/spacelift-launcher | cut -f 1 -d ' ')
+echo "Verifying launcher binary..." >> /var/log/spacelift/info.log
+if [[ "$CHECKSUM" == "$LAUNCHER_SHA" ]]; then
+  echo "OK\!" >> /var/log/spacelift/info.log
+else
+  echo "Checksum and launcher binary hash did not match" >> /var/log/spacelift/error.log
+  return 1
+fi
+echo "Making the Spacelift launcher executable" >> /var/log/spacelift/info.log
+chmod 755 /usr/bin/spacelift-launcher 2>>/var/log/spacelift/error.log
+
+# Get instance metadata
+echo "Retrieving Azure VM Name" >> /var/log/spacelift/info.log
+export SPACELIFT_METADATA_vm_name=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq ".compute.name")
+echo "Retrieving Azure VM Resource ID" >> /var/log/spacelift/info.log
+export SPACELIFT_METADATA_vm_resource_id=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq ".compute.resourceId")
+echo "Retrieving Azure VMSS Name" >> /var/log/spacelift/info.log
+export SPACELIFT_METADATA_vmss_name=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq ".compute.vmScaleSetName")
+
+echo "Starting the Spacelift binary" >> /var/log/spacelift/info.log
+/usr/bin/spacelift-launcher 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+)}
+spacelift
+echo "Powering off in 15 seconds" >> /var/log/spacelift/error.log
+sleep 15
+poweroff
+  EOF
+
+  worker_script = base64encode(
+    join("\n", [
+      local.worker_script_head,
+      var.configuration,
+      local.worker_script_tail,
+    ])
+  )
+
+  user_data = <<EOF
+#!/bin/bash
+
+# Write the launcher script out to a file in the `per-boot` folder to ensure it restarts if the VM is rebooted
+echo "${local.worker_script}" | base64 --decode > /var/lib/cloud/scripts/per-boot/spacelift-boot.sh
+chmod 744 /var/lib/cloud/scripts/per-boot/spacelift-boot.sh
+
+/var/lib/cloud/scripts/per-boot/spacelift-boot.sh
+  EOF
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "this" {
+  name                = local.namespace
+  resource_group_name = var.resource_group.name
+  location            = var.resource_group.location
+  sku                 = var.vmss_sku
+
+  instances      = var.vmss_instances
+  admin_username = var.admin_username
+  admin_password = var.admin_password
+
+  dynamic "admin_ssh_key" {
+    for_each = var.admin_public_key != null ? [0] : []
+    content {
+      username   = var.admin_username
+      public_key = base64decode(var.admin_public_key)
+    }
+  }
+
+  source_image_id = var.source_image_id
+
+  dynamic "source_image_reference" {
+    for_each = var.source_image_id == null ? [0] : []
+    content {
+      publisher = var.source_image_publisher
+      offer     = var.source_image_offer
+      sku       = var.source_image_sku
+      version   = var.source_image_version
+    }
+  }
+
+  dynamic "plan" {
+    for_each = var.source_image_id == null ? [0] : []
+    content {
+      publisher = var.source_image_publisher
+      name      = var.source_image_sku
+      product   = var.source_image_offer
+    }
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  network_interface {
+    name    = "spacelift-worker-nic"
+    primary = true
+
+    ip_configuration {
+      name                           = "internal"
+      primary                        = true
+      subnet_id                      = var.subnet_id
+      application_security_group_ids = var.application_security_group_ids
+    }
+  }
+
+  overprovision = var.overprovision
+
+  dynamic "identity" {
+    for_each = var.identity_type != null ? [0] : []
+    content {
+      type         = var.identity_type
+      identity_ids = var.identity_ids
+    }
+  }
+
+  custom_data = base64encode(local.user_data)
+
+  scale_in_policy = "OldestVM"
+
+  tags = merge(var.tags,
+    {
+      WorkerPoolID : var.worker_pool_id
+    }
+  )
+}


### PR DESCRIPTION
I've added the terraform definitions to create an Azure VMSS running a Spacelift private worker pool. The way it works is pretty similar to https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2, but just using an Azure VMSS instead of an AWS ASG.

One change that I've made compared to the AWS version is that I'm storing the startup script in the `/var/lib/cloud/scripts/per-boot` rather than passing it as the user_data directly. This means that the worker starts again if the instance is rebooted.

I'll add some examples of how to use the module, but I want to do that separately to avoid the commits being huge.