### PR TITLE
Add example of using a Bastion host for ssh

### DIFF
--- a/examples/azure-private-worker-bastion/README.md
+++ b/examples/azure-private-worker-bastion/README.md
@@ -1,0 +1,26 @@
+# Private Worker with Bastion for SSH
+
+This example shows how to provision a Spacelift private worker using an Azure VMSS, along with
+a [Bastion](https://docs.microsoft.com/en-gb/azure/bastion/) host to allow you to connect to
+the VM instances. It also uses KeyVault to store the SSH key for connecting to the VM instances,
+along with the credentials required for the worker pool to authenticate with Spacelift.
+
+## Usage
+
+To run the example, create a tfvars file with the following variables specified:
+
+```hcl
+admin_public_key = "<your-base64-encoded-ssh-public-key>"
+admin_private_key = "<your-base64-encoded-ssh-private-key>"
+worker_pool_config = "<your-worker-pool-config>"
+worker_pool_private_key = "<your-worker-pool-private-key>"
+worker_pool_id = "<your-worker-pool-id>"
+location = "West Europe"
+```
+
+Now just initialise Terraform, and run an apply:
+
+```shell
+terraform init
+terraform apply -var-file myvars.tfvars
+```

--- a/examples/azure-private-worker-bastion/bastion.tf
+++ b/examples/azure-private-worker-bastion/bastion.tf
@@ -1,0 +1,25 @@
+# The public IP you connect to your Bastion host via
+resource "azurerm_public_ip" "bastion" {
+  name                = "ip-bastion-${local.namespace}"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  tags = local.tags
+}
+
+# The Bastion host
+resource "azurerm_bastion_host" "this" {
+  name                = "bas-${local.namespace}"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                 = "public-access"
+    subnet_id            = azurerm_subnet.bastion.id
+    public_ip_address_id = azurerm_public_ip.bastion.id
+  }
+
+  tags = local.tags
+}

--- a/examples/azure-private-worker-bastion/data.tf
+++ b/examples/azure-private-worker-bastion/data.tf
@@ -1,0 +1,1 @@
+data "azurerm_client_config" "current" {}

--- a/examples/azure-private-worker-bastion/group.tf
+++ b/examples/azure-private-worker-bastion/group.tf
@@ -1,0 +1,6 @@
+resource "azurerm_resource_group" "this" {
+  name     = "rg-${local.namespace}"
+  location = var.location
+
+  tags = local.tags
+}

--- a/examples/azure-private-worker-bastion/identity.tf
+++ b/examples/azure-private-worker-bastion/identity.tf
@@ -1,0 +1,18 @@
+# Create a user-assigned identity for the VMSS. This allows us to grant it permissions
+# over our subscription, as well as configure its access to KeyVault secrets.
+resource "azurerm_user_assigned_identity" "vmss" {
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  name                = "sp5ft-${var.worker_pool_id}"
+}
+
+data "azurerm_subscription" "primary" {
+}
+
+# Grant the VMSS instances access to our current subscription. You may want to remove this
+# and grant permissions separately, or grant more restrictive permissions.
+resource "azurerm_role_assignment" "vmss_contributor" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.vmss.principal_id
+}

--- a/examples/azure-private-worker-bastion/keyvault.tf
+++ b/examples/azure-private-worker-bastion/keyvault.tf
@@ -1,0 +1,64 @@
+# KeyVault names need to be globally unique, so we'll just generate a random ID with a specified prefix.
+resource "random_id" "keyvault" {
+  byte_length = 9
+  prefix      = "sp5ft"
+}
+
+resource "azurerm_key_vault" "this" {
+  name                       = random_id.keyvault.hex
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+
+  # Allow the user running the apply access to KeyVault. You may want to configure
+  # policies for other users/groups in your organization.
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Set",
+      "Get",
+      "List",
+      "Delete",
+      "Purge",
+      "Recover"
+    ]
+  }
+
+  # Grant the VMSS identity permission to download secrets.
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.vmss.principal_id
+
+    secret_permissions = [
+      "Get"
+    ]
+  }
+}
+
+# Uploading the private key to KeyVault allows it to be selected when connecting via Bastion.
+resource "azurerm_key_vault_secret" "ssh_private_key" {
+  name         = "ssh-private-key"
+  value        = base64decode(var.admin_private_key)
+  key_vault_id = azurerm_key_vault.this.id
+}
+
+resource "azurerm_key_vault_secret" "worker_pool_config" {
+  name         = "worker-pool-config"
+  value        = base64encode(var.worker_pool_config)
+  key_vault_id = azurerm_key_vault.this.id
+}
+
+resource "azurerm_key_vault_secret" "worker_pool_private_key" {
+  name         = "worker-pool-private-key"
+  value        = base64encode(var.worker_pool_private_key)
+  key_vault_id = azurerm_key_vault.this.id
+}

--- a/examples/azure-private-worker-bastion/main.tf
+++ b/examples/azure-private-worker-bastion/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.46.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "=3.1.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}
+
+module "azure-worker" {
+  source = "../../"
+
+  admin_username   = var.admin_username
+  admin_public_key = var.admin_public_key
+
+  # This custom configuration block logs into Azure, downloads the worker pool credentials
+  # from KeyVault, and then configures the environment variables the Spacelift worker will
+  # read them from.
+  configuration = <<-EOT
+    az login --identity
+
+    echo "Downloading worker pool credentials from KeyVault" >> /var/log/spacelift/info.log
+    az keyvault secret download --name "${azurerm_key_vault_secret.worker_pool_config.name}" \
+      --vault-name "${azurerm_key_vault.this.name}" \
+      --file "/tmp/worker-pool-config" 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+
+    az keyvault secret download --name "${azurerm_key_vault_secret.worker_pool_private_key.name}" \
+      --vault-name "${azurerm_key_vault.this.name}" \
+      --file "/tmp/worker-pool-private-key" 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+
+    export SPACELIFT_TOKEN=$(cat /tmp/worker-pool-config | base64 --decode)
+    export SPACELIFT_POOL_PRIVATE_KEY=$(cat /tmp/worker-pool-private-key | base64 --decode)
+
+    rm /tmp/worker-pool-config
+    rm /tmp/worker-pool-private-key
+
+    echo "Worker pool credentials configured" >> /var/log/spacelift/info.log
+  EOT
+
+  resource_group                 = azurerm_resource_group.this
+  subnet_id                      = azurerm_subnet.worker.id
+  application_security_group_ids = [azurerm_application_security_group.linux.id]
+
+  identity_type = "UserAssigned"
+  identity_ids  = [azurerm_user_assigned_identity.vmss.id]
+
+  worker_pool_id = var.worker_pool_id
+  name_prefix    = "sp5ft-bastion"
+  tags           = local.tags
+
+  depends_on = [
+    azurerm_role_assignment.vmss_contributor
+  ]
+}

--- a/examples/azure-private-worker-bastion/network.tf
+++ b/examples/azure-private-worker-bastion/network.tf
@@ -1,0 +1,190 @@
+locals {
+  bastion_subnet_address_prefix = "10.0.1.0/26"
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+}
+
+# Create a subnet for our workers
+resource "azurerm_subnet" "worker" {
+  name                 = "worker"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+# Create a subnet for the Bastion host
+resource "azurerm_subnet" "bastion" {
+  name                 = "AzureBastionSubnet"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [local.bastion_subnet_address_prefix]
+}
+
+resource "azurerm_application_security_group" "linux" {
+  name                = "linux"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  tags = local.tags
+}
+
+# Create an NSG for the worker pool, denying all inbound access except via the Bastion host.
+resource "azurerm_network_security_group" "worker" {
+  name                = "worker"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+
+  # Allow SSH from the bastion subnet
+  security_rule {
+    name                                       = "AllowBastionSSHInbound"
+    priority                                   = 100
+    direction                                  = "Inbound"
+    access                                     = "Allow"
+    protocol                                   = "Tcp"
+    source_address_prefix                      = local.bastion_subnet_address_prefix
+    source_port_range                          = "*"
+    destination_port_range                     = "22"
+    destination_application_security_group_ids = [azurerm_application_security_group.linux.id]
+  }
+
+  # Deny all other inbound traffic
+  security_rule {
+    name                       = "DenyAllInbound"
+    priority                   = 1000
+    direction                  = "Inbound"
+    access                     = "Deny"
+    protocol                   = "*"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    destination_address_prefix = "*"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "worker" {
+  subnet_id                 = azurerm_subnet.worker.id
+  network_security_group_id = azurerm_network_security_group.worker.id
+}
+
+resource "azurerm_network_security_group" "bastion" {
+  name                = "bastion"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  # The NSG rules defined here are required for Bastion to function. They're described
+  # at https://docs.microsoft.com/en-us/azure/bastion/bastion-nsg.
+
+  # Inbound rules
+  security_rule {
+    name                       = "AllowBastionHTTPSInbound"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_address_prefix      = "Internet"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "AllowBastionGatewayManagerInbound"
+    priority                   = 101
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_address_prefix      = "GatewayManager"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "AllowBastionAzureLBInbound"
+    priority                   = 102
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_address_prefix      = "AzureLoadBalancer"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "AllowBastionHostCommunication"
+    priority                   = 103
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_address_prefix      = "VirtualNetwork"
+    source_port_range          = "*"
+    destination_port_ranges    = ["8080", "5701"]
+    destination_address_prefix = "VirtualNetwork"
+  }
+
+  # Outbound rules
+  security_rule {
+    name                       = "AllowBastionSSHRDPOutbound"
+    priority                   = 200
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_port_ranges    = ["22", "3389"]
+    destination_address_prefix = "VirtualNetwork"
+  }
+
+  security_rule {
+    name                       = "AllowBastionAzureCloudOutbound"
+    priority                   = 201
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    destination_address_prefix = "AzureCloud"
+  }
+
+  security_rule {
+    name                       = "AllowBastionHostCommunicationOutbound"
+    priority                   = 202
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_address_prefix      = "VirtualNetwork"
+    source_port_range          = "*"
+    destination_port_ranges    = ["8080", "5701"]
+    destination_address_prefix = "VirtualNetwork"
+  }
+
+  security_rule {
+    name                       = "AllowBastionGetSessionInfoOutbound"
+    priority                   = 203
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_address_prefix      = "*"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    destination_address_prefix = "Internet"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "bastion" {
+  subnet_id                 = azurerm_subnet.bastion.id
+  network_security_group_id = azurerm_network_security_group.bastion.id
+}

--- a/examples/azure-private-worker-bastion/variables.tf
+++ b/examples/azure-private-worker-bastion/variables.tf
@@ -1,0 +1,48 @@
+locals {
+  namespace = "${var.application}-${var.env}"
+
+  tags = {
+    application = var.application
+    env         = var.env
+    region      = var.location
+  }
+}
+
+variable "admin_username" {
+  type    = string
+  default = "spacelift"
+}
+
+variable "application" {
+  type    = string
+  default = "sp5ft-private-worker-bastion"
+}
+
+variable "admin_public_key" {
+  type = string
+}
+
+variable "admin_private_key" {
+  type = string
+}
+
+variable "env" {
+  type    = string
+  default = "test"
+}
+
+variable "location" {
+  type = string
+}
+
+variable "worker_pool_config" {
+  type = string
+}
+
+variable "worker_pool_private_key" {
+  type = string
+}
+
+variable "worker_pool_id" {
+  type = string
+}


### PR DESCRIPTION
This example shows a few things:

- Creating a Bastion host to allow ssh access without allowing direct public access to the VMSS instances.
- Using KeyVault to upload the worker pool credentials and SSH key for Bastion.