### PR TITLE
Allow the process exit behavior to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ module "azure-worker" {
     export SPACELIFT_POOL_PRIVATE_KEY="${var.worker_pool_private_key}"
   EOT
 
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  subnet_id           = var.subnet_id
-  worker_pool_id      = var.worker_pool_id
+  resource_group = var.resource_group # An azurerm_resource_group object - must have `name` and `location` properties
+  subnet_id      = var.subnet_id
+  worker_pool_id = var.worker_pool_id
 }
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,16 @@ variable "worker_pool_id" {
   description = "The ID of the Spacelift worker pool."
 }
 
+variable "process_exit_behavior" {
+  type        = string
+  description = "The behavior to use when the Spacelift process exits"
+  default     = "Reboot"
+  validation {
+    condition     = can(regex("^(Reboot|Shutdown|None)$", var.process_exit_behavior))
+    error_message = "The process_exit_behavior value must be one of: [Reboot, Shutdown, None]."
+  }
+}
+
 locals {
   namespace = "${var.name_prefix}-${var.worker_pool_id}"
 }


### PR DESCRIPTION
When the VM is shutdown in Azure, it just stays in a turned off state, and Azure doesn't automatically replace it. We could probably setup a health check that failed if the spacelift process wasn't running, but for now I figured it's easier to just reboot the VM rather than turning it off.

I've added three options:

- Reboot - reboots the VM, which will cause the worker to be updated.
- Shutdown - shuts down the VM.
- None - does nothing. This is useful if there's a configuration issue, and you want to be able to connect to investigate.

I've also fixed a mistake in the usage info in the README file.