### PR TITLE
Add a user-assigned identity example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,8 @@ More information can be found [here](https://go.microsoft.com/fwlink/?linkid=211
 The following examples of using the module are available:
 
 - [Bastion](./examples/bastion/README.md) - creates a worker with a Bastion host for ssh access.
-- [System-Assigned Identity](./examples/system-assigned-identity/README.md) - creates a worker with a system-assigned identity.
+- [System-Assigned Identity](./examples/system-assigned-identity/README.md) - creates a worker
+  with a system-assigned identity.
+- [User-Assigned Identity](./examples/user-assigned-identity/README.md) - creates a worker with
+  a user-assigned identity, and shows how to use that identity to access the worker pool credentials
+  via KeyVault secrets.

--- a/examples/user-assigned-identity/README.md
+++ b/examples/user-assigned-identity/README.md
@@ -1,0 +1,38 @@
+# Private Worker with a User Assigned Identity
+
+This example shows how to provision a Spacelift private worker using an Azure VMSS, using a
+User-Assigned Managed Identity to grant the workers permission to manage your Azure subscription.
+It also creates a KeyVault to store the worker pool credentials in, and uses the user-assigned
+identity to grant the VMSS permission to those secrets.
+
+Using a user-assigned managed identity gives you more control than using a [system-assigned identity](../system-assigned-identity/README.md),
+allowing you to do things like provision secrets in KeyVault and grant the correct permissions
+before your scale set is created.
+
+**NOTES:**
+
+- When using a user-assigned identity, you need to pass the identity's `client_id`
+  to the Terraform provider via the `ARM_CLIENT_ID` environment variable when following the
+  [authentication instructions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/managed_service_identity).
+- Although we're using KeyVault to store the secrets, please note that the Azure RM provider
+  stores the secret values in plain text in your state, so the usual warnings about treating
+  your state as a secret apply.
+
+## Usage
+
+To run the example, create a tfvars file with the following variables specified:
+
+```hcl
+admin_public_key = "<your-base64-encoded-ssh-public-key>"
+worker_pool_config = "<your-worker-pool-config>"
+worker_pool_private_key = "<your-worker-pool-private-key>"
+worker_pool_id = "<your-worker-pool-id>"
+location = "West Europe"
+```
+
+Now just initialise Terraform, and run an apply:
+
+```shell
+terraform init
+terraform apply -var-file myvars.tfvars
+```

--- a/examples/user-assigned-identity/data.tf
+++ b/examples/user-assigned-identity/data.tf
@@ -1,0 +1,2 @@
+data "azurerm_client_config" "current" {}
+data "azurerm_subscription" "primary" {}

--- a/examples/user-assigned-identity/group.tf
+++ b/examples/user-assigned-identity/group.tf
@@ -1,0 +1,6 @@
+resource "azurerm_resource_group" "this" {
+  name     = "rg-${local.namespace}"
+  location = var.location
+
+  tags = local.tags
+}

--- a/examples/user-assigned-identity/identity.tf
+++ b/examples/user-assigned-identity/identity.tf
@@ -1,0 +1,15 @@
+# Create a user-assigned identity for the VMSS. This allows us to grant it permissions
+# over our subscription, as well as configure its access to KeyVault secrets.
+resource "azurerm_user_assigned_identity" "vmss" {
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  name                = "sp5ft-${var.worker_pool_id}"
+}
+
+# Grant the VMSS instances access to our current subscription. You may want to remove this
+# and grant permissions separately, or grant more restrictive permissions.
+resource "azurerm_role_assignment" "vmss_contributor" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.vmss.principal_id
+}

--- a/examples/user-assigned-identity/keyvault.tf
+++ b/examples/user-assigned-identity/keyvault.tf
@@ -1,0 +1,57 @@
+# KeyVault names need to be globally unique, so we'll just generate a random ID with a specified prefix.
+resource "random_id" "keyvault" {
+  byte_length = 9
+  prefix      = "sp5ft"
+}
+
+resource "azurerm_key_vault" "this" {
+  name                       = random_id.keyvault.hex
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+
+  # Allow the user running the apply access to KeyVault. You may want to configure
+  # policies for other users/groups in your organization.
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Set",
+      "Get",
+      "List",
+      "Delete",
+      "Purge",
+      "Recover"
+    ]
+  }
+
+  # Grant the VMSS identity permission to download secrets.
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.vmss.principal_id
+
+    secret_permissions = [
+      "Get"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "worker_pool_config" {
+  name         = "worker-pool-config"
+  value        = base64encode(var.worker_pool_config)
+  key_vault_id = azurerm_key_vault.this.id
+}
+
+resource "azurerm_key_vault_secret" "worker_pool_private_key" {
+  name         = "worker-pool-private-key"
+  value        = base64encode(var.worker_pool_private_key)
+  key_vault_id = azurerm_key_vault.this.id
+}

--- a/examples/user-assigned-identity/main.tf
+++ b/examples/user-assigned-identity/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.46.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "=3.1.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}
+
+module "azure-worker" {
+  source = "../../"
+
+  admin_username   = var.admin_username
+  admin_public_key = var.admin_public_key
+
+  # This custom configuration block logs into Azure, downloads the worker pool credentials
+  # from KeyVault, and then configures the environment variables the Spacelift worker will
+  # read them from.
+  configuration = <<-EOT
+    az login --identity
+
+    echo "Downloading worker pool credentials from KeyVault" >> /var/log/spacelift/info.log
+    az keyvault secret download --name "${azurerm_key_vault_secret.worker_pool_config.name}" \
+      --vault-name "${azurerm_key_vault.this.name}" \
+      --file "/tmp/worker-pool-config" 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+
+    az keyvault secret download --name "${azurerm_key_vault_secret.worker_pool_private_key.name}" \
+      --vault-name "${azurerm_key_vault.this.name}" \
+      --file "/tmp/worker-pool-private-key" 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+
+    export SPACELIFT_TOKEN=$(cat /tmp/worker-pool-config | base64 --decode)
+    export SPACELIFT_POOL_PRIVATE_KEY=$(cat /tmp/worker-pool-private-key | base64 --decode)
+
+    rm /tmp/worker-pool-config
+    rm /tmp/worker-pool-private-key
+
+    echo "Worker pool credentials configured" >> /var/log/spacelift/info.log
+  EOT
+
+  resource_group = azurerm_resource_group.this
+  subnet_id      = azurerm_subnet.worker.id
+
+  identity_type = "UserAssigned"
+  identity_ids  = [azurerm_user_assigned_identity.vmss.id]
+
+  worker_pool_id = var.worker_pool_id
+  name_prefix    = "sp5ft-user-identity"
+  tags           = local.tags
+
+  depends_on = [
+    azurerm_role_assignment.vmss_contributor
+  ]
+}

--- a/examples/user-assigned-identity/network.tf
+++ b/examples/user-assigned-identity/network.tf
@@ -1,0 +1,15 @@
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+}
+
+# Create a subnet for our workers
+resource "azurerm_subnet" "worker" {
+  name                 = "worker"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = ["10.0.2.0/24"]
+}

--- a/examples/user-assigned-identity/outputs.tf
+++ b/examples/user-assigned-identity/outputs.tf
@@ -1,0 +1,3 @@
+output "identity_client_id" {
+  value = azurerm_user_assigned_identity.vmss.client_id
+}

--- a/examples/user-assigned-identity/variables.tf
+++ b/examples/user-assigned-identity/variables.tf
@@ -1,0 +1,44 @@
+locals {
+  namespace = "${var.application}-${var.env}"
+
+  tags = {
+    application = var.application
+    env         = var.env
+    region      = var.location
+  }
+}
+
+variable "admin_username" {
+  type    = string
+  default = "spacelift"
+}
+
+variable "application" {
+  type    = string
+  default = "sp5ft-user-identity"
+}
+
+variable "admin_public_key" {
+  type = string
+}
+
+variable "env" {
+  type    = string
+  default = "test"
+}
+
+variable "location" {
+  type = string
+}
+
+variable "worker_pool_config" {
+  type = string
+}
+
+variable "worker_pool_private_key" {
+  type = string
+}
+
+variable "worker_pool_id" {
+  type = string
+}


### PR DESCRIPTION
Added an example of using a user-assigned identity, and using that identity to grant access to KeyVault secrets.