### PR TITLE
Add module tests

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,0 +1,6 @@
+version: 1
+module_version: 0.0.1
+
+tests:
+  - name: System-assigned identity
+    project_root: examples/system-assigned-identity

--- a/examples/bastion/group.tf
+++ b/examples/bastion/group.tf
@@ -1,5 +1,7 @@
+resource "random_pet" "this" {}
+
 resource "azurerm_resource_group" "this" {
-  name     = "rg-${local.namespace}"
+  name     = "rg-${var.application}-${random_pet.this.id}-${var.env}"
   location = var.location
 
   tags = local.tags

--- a/examples/bastion/identity.tf
+++ b/examples/bastion/identity.tf
@@ -6,10 +6,9 @@ resource "azurerm_user_assigned_identity" "vmss" {
   name                = "sp5ft-${var.worker_pool_id}"
 }
 
-# Grant the VMSS instances access to our current subscription. You may want to remove this
-# and grant permissions separately, or grant more restrictive permissions.
-resource "azurerm_role_assignment" "vmss_contributor" {
-  scope                = data.azurerm_subscription.primary.id
-  role_definition_name = "Contributor"
-  principal_id         = azurerm_user_assigned_identity.vmss.principal_id
-}
+# Uncomment the following resource to grant the VMSS instances access to your current subscription.
+# resource "azurerm_role_assignment" "vmss_contributor" {
+#   scope                = data.azurerm_subscription.primary.id
+#   role_definition_name = "Contributor"
+#   principal_id         = azurerm_user_assigned_identity.vmss.principal_id
+# }

--- a/examples/bastion/main.tf
+++ b/examples/bastion/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.46.0"
+      version = "=2.68.0"
     }
 
     random = {
@@ -16,6 +16,8 @@ terraform {
 provider "azurerm" {
   features {}
 }
+
+resource "random_pet" "this" {}
 
 module "azure-worker" {
   source = "../../"

--- a/examples/bastion/variables.tf
+++ b/examples/bastion/variables.tf
@@ -32,7 +32,8 @@ variable "env" {
 }
 
 variable "location" {
-  type = string
+  type    = string
+  default = "westeurope"
 }
 
 variable "worker_pool_config" {

--- a/examples/system-assigned-identity/group.tf
+++ b/examples/system-assigned-identity/group.tf
@@ -1,5 +1,7 @@
+resource "random_pet" "this" {}
+
 resource "azurerm_resource_group" "this" {
-  name     = "rg-${local.namespace}"
+  name     = "rg-${var.application}-${random_pet.this.id}-${var.env}"
   location = var.location
 
   tags = local.tags

--- a/examples/system-assigned-identity/identity.tf
+++ b/examples/system-assigned-identity/identity.tf
@@ -1,7 +1,6 @@
-# Grant the VMSS instances access to our current subscription. You may want to remove this
-# and grant permissions separately, or grant more restrictive permissions.
-resource "azurerm_role_assignment" "vmss_contributor" {
-  scope                = data.azurerm_subscription.primary.id
-  role_definition_name = "Contributor"
-  principal_id         = module.azure-worker.identity[0].principal_id
-}
+# Uncomment the following resource to grant the VMSS instances access to your current subscription.
+# resource "azurerm_role_assignment" "vmss_contributor" {
+#   scope                = data.azurerm_subscription.primary.id
+#   role_definition_name = "Contributor"
+#   principal_id         = module.azure-worker.identity[0].principal_id
+# }

--- a/examples/system-assigned-identity/main.tf
+++ b/examples/system-assigned-identity/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.46.0"
+      version = "=2.68.0"
     }
 
     random = {

--- a/examples/system-assigned-identity/variables.tf
+++ b/examples/system-assigned-identity/variables.tf
@@ -28,7 +28,8 @@ variable "env" {
 }
 
 variable "location" {
-  type = string
+  type    = string
+  default = "westeurope"
 }
 
 variable "worker_pool_config" {

--- a/examples/user-assigned-identity/group.tf
+++ b/examples/user-assigned-identity/group.tf
@@ -1,5 +1,7 @@
+resource "random_pet" "this" {}
+
 resource "azurerm_resource_group" "this" {
-  name     = "rg-${local.namespace}"
+  name     = "rg-${var.application}-${random_pet.this.id}-${var.env}"
   location = var.location
 
   tags = local.tags

--- a/examples/user-assigned-identity/identity.tf
+++ b/examples/user-assigned-identity/identity.tf
@@ -6,10 +6,9 @@ resource "azurerm_user_assigned_identity" "vmss" {
   name                = "sp5ft-${var.worker_pool_id}"
 }
 
-# Grant the VMSS instances access to our current subscription. You may want to remove this
-# and grant permissions separately, or grant more restrictive permissions.
-resource "azurerm_role_assignment" "vmss_contributor" {
-  scope                = data.azurerm_subscription.primary.id
-  role_definition_name = "Contributor"
-  principal_id         = azurerm_user_assigned_identity.vmss.principal_id
-}
+# Uncomment the following resource to grant the VMSS instances access to your current subscription.
+# resource "azurerm_role_assignment" "vmss_contributor" {
+#   scope                = data.azurerm_subscription.primary.id
+#   role_definition_name = "Contributor"
+#   principal_id         = azurerm_user_assigned_identity.vmss.principal_id
+# }

--- a/examples/user-assigned-identity/main.tf
+++ b/examples/user-assigned-identity/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.46.0"
+      version = "=2.68.0"
     }
 
     random = {

--- a/examples/user-assigned-identity/variables.tf
+++ b/examples/user-assigned-identity/variables.tf
@@ -1,6 +1,4 @@
 locals {
-  namespace = "${var.application}-${var.env}"
-
   tags = {
     application = var.application
     env         = var.env
@@ -28,7 +26,8 @@ variable "env" {
 }
 
 variable "location" {
-  type = string
+  type    = string
+  default = "westeurope"
 }
 
 variable "worker_pool_config" {


### PR DESCRIPTION
- Added a module config file, using the system-assigned identity example as a test case. The reason I used it is because it's the simplest out of the three examples (in terms of other infra that gets created), but it still creates the worker pool.
- Bumped the Azure RM module version - it turns out their docs reference an out of date version that has an issue destroying KV secrets.
- Adjusted the examples to allow a randomly generated worker pool ID to allow multiple PRs to trigger the tests without causing issues.