### PR TITLE
Fix issues with Bastion example

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.0.1
+module_version: 0.0.2
 
 tests:
   - name: System-assigned identity

--- a/examples/bastion/main.tf
+++ b/examples/bastion/main.tf
@@ -17,8 +17,6 @@ provider "azurerm" {
   features {}
 }
 
-resource "random_pet" "this" {}
-
 module "azure-worker" {
   source = "../../"
 
@@ -59,8 +57,4 @@ module "azure-worker" {
   worker_pool_id = var.worker_pool_id
   name_prefix    = "sp5ft-bastion"
   tags           = local.tags
-
-  depends_on = [
-    azurerm_role_assignment.vmss_contributor
-  ]
 }

--- a/examples/user-assigned-identity/main.tf
+++ b/examples/user-assigned-identity/main.tf
@@ -56,8 +56,4 @@ module "azure-worker" {
   worker_pool_id = var.worker_pool_id
   name_prefix    = "sp5ft-user-identity"
   tags           = local.tags
-
-  depends_on = [
-    azurerm_role_assignment.vmss_contributor
-  ]
 }


### PR DESCRIPTION
## Description of the change

The `random_pet` declared in main.tf was a duplicate that I added by accident when moving the random ID to the resource group name.

I've removed the dependency on the `vmss_contributor` role assignment - there isn't much point since the VMs don't need that assignment to start, and I deliberately left the assignment commented out just as an example since it's not required.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
