### PR TITLE
Remove quotes from metadata

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.0.3
+module_version: 0.0.4
 
 tests:
   - name: System-assigned identity

--- a/vmss.tf
+++ b/vmss.tf
@@ -50,11 +50,11 @@ chmod 755 /usr/bin/spacelift-launcher 2>>/var/log/spacelift/error.log
 
 # Get instance metadata
 echo "Retrieving Azure VM Name" >> /var/log/spacelift/info.log
-export SPACELIFT_METADATA_vm_name=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq ".compute.name")
+export SPACELIFT_METADATA_instance_id=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r ".compute.name")
 echo "Retrieving Azure VM Resource ID" >> /var/log/spacelift/info.log
-export SPACELIFT_METADATA_vm_resource_id=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq ".compute.resourceId")
+export SPACELIFT_METADATA_vm_resource_id=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r ".compute.resourceId")
 echo "Retrieving Azure VMSS Name" >> /var/log/spacelift/info.log
-export SPACELIFT_METADATA_vmss_name=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq ".compute.vmScaleSetName")
+export SPACELIFT_METADATA_vmss_name=$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq -r ".compute.vmScaleSetName")
 
 echo "Starting the Spacelift binary" >> /var/log/spacelift/info.log
 /usr/bin/spacelift-launcher 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log


### PR DESCRIPTION
## Description of the change

- Passing the `-r` flag to `jq` to avoid it quoting the environment variables.
- Changed the `vm_name` metadata item to `instance_id` since we're using it as a tag in our metrics. I think that's the closest Azure equivalent.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
