### PR TITLE
Introduce Spacelift Community Gallery

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 0.1.0
+module_version: 1.0.0
 
 tests:
   - name: System-assigned identity

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Terraform module for deploying a Spacelift worker pool on Azure using a VMSS.
 
 ## Usage
 
-NOTE: please make sure you [accept the terms](#accepting-terms) for our Azure Marketplace
-image before trying to use the module.
-
 ```hcl
 terraform {
   required_providers {
@@ -18,7 +15,7 @@ terraform {
 }
 
 module "azure-worker" {
-  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v0.1.0"
+  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v1.0.0"
 
   admin_password = "Super Secret Password!"
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,31 +67,31 @@ variable "resource_group" {
 variable "source_image_id" {
   type        = string
   description = "The VM image to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
-  default     = null
+  default     = "/communityGalleries/spacelift-40913cda-9bf9-4bcb-bf90-78fd83f30079/images/spacelift_worker_image/versions/latest"
 }
 
 variable "source_image_publisher" {
   type        = string
   description = "The image publisher to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
-  default     = "spaceliftinc1625499025476"
+  default     = null
 }
 
 variable "source_image_offer" {
   type        = string
   description = "The image offer to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
-  default     = "spacelift_worker"
+  default     = null
 }
 
 variable "source_image_sku" {
   type        = string
   description = "The image SKU to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
-  default     = "ubuntu_20_04"
+  default     = null
 }
 
 variable "source_image_version" {
   type        = string
   description = "The image version to use. Either source_image_id, or a combination of source_image_publisher, source_image_offer, source_image_sku, and source_image_version must be specified."
-  default     = "latest"
+  default     = null
 }
 
 variable "subnet_id" {


### PR DESCRIPTION
## Description of the change

We're moving from using Azure Marketplace to a Community Gallery to streamline our processes. From v1.0.0 the base image will be pulled from Spacelift's community gallery instead of Azure Marketplace.

Related issue:
- https://github.com/hashicorp/terraform-provider-azurerm/issues/19016

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
