### PR TITLE
feat: download correct binary when in FedRAMP environment

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.0.0
+module_version: 1.1.0
 
 tests:
   - name: System-assigned identity

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
 }
 
 module "azure-worker" {
-  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v1.0.0"
+  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v1.1.0"
 
   admin_password = "Super Secret Password!"
 

--- a/examples/bastion/main.tf
+++ b/examples/bastion/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.61.0"
+      version = "=4.42.0"
     }
 
     random = {
@@ -15,6 +15,7 @@ terraform {
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
   features {}
+  resource_provider_registrations = "none"
 }
 
 module "azure-worker" {

--- a/examples/password-authentication/main.tf
+++ b/examples/password-authentication/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.61.0"
+      version = "=4.42.0"
     }
 
     random = {
@@ -15,6 +15,7 @@ terraform {
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
   features {}
+  resource_provider_registrations = "none"
 }
 
 module "azure-worker" {

--- a/examples/system-assigned-identity/main.tf
+++ b/examples/system-assigned-identity/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.61.0"
+      version = "=4.42.0"
     }
 
     random = {
@@ -15,6 +15,7 @@ terraform {
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
   features {}
+  resource_provider_registrations = "none"
 }
 
 module "azure-worker" {

--- a/examples/user-assigned-identity/main.tf
+++ b/examples/user-assigned-identity/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.61.0"
+      version = "=4.42.0"
     }
 
     random = {
@@ -15,6 +15,7 @@ terraform {
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
   features {}
+  resource_provider_registrations = "none"
 }
 
 module "azure-worker" {

--- a/vmss.tf
+++ b/vmss.tf
@@ -27,7 +27,20 @@ if [[ "$currentArch" != "x86_64" && "$currentArch" != "aarch64" ]]; then
   return 1
 fi
 
-baseURL="https://downloads.${var.domain_name}/spacelift-launcher"
+# Check if we're connecting to FedRAMP environment by decoding SPACELIFT_TOKEN
+fedrampSuffix=""
+if [[ -n "$SPACELIFT_TOKEN" ]]; then
+  # Decode the base64 token and extract broker endpoint
+  decoded_token=$(echo "$SPACELIFT_TOKEN" | base64 -d 2>/dev/null || echo "")
+  if [[ -n "$decoded_token" ]]; then
+    broker_endpoint=$(echo "$decoded_token" | jq -r '.broker.endpoint' 2>/dev/null || echo "")
+    if [[ "$broker_endpoint" == *".gov.spacelift.io" ]]; then
+      fedrampSuffix="-fedramp"
+    fi
+  fi
+fi
+
+baseURL="https://downloads.${var.domain_name}/spacelift-launcher$fedrampSuffix"
 binaryURL=$(printf "%s-%s" "$baseURL" "$currentArch")
 shaSumURL=$(printf "%s-%s_%s" "$baseURL" "$currentArch" "SHA256SUMS")
 shaSumSigURL=$(printf "%s-%s_%s" "$baseURL" "$currentArch" "SHA256SUMS.sig")
@@ -38,7 +51,7 @@ if [[ "${var.perform_unattended_upgrade_on_boot}" == "true" ]]; then
   unattended-upgrade -d 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
 fi
 
-echo "Downloading Spacelift launcher" >> /var/log/spacelift/info.log
+echo "Downloading Spacelift launcher from $binaryURL" >> /var/log/spacelift/info.log
 curl "$binaryURL" --output /usr/bin/spacelift-launcher 2>>/var/log/spacelift/error.log
 echo "Importing public GPG key" >> /var/log/spacelift/info.log
 curl https://keys.openpgp.org/vks/v1/by-fingerprint/175FD97AD2358EFE02832978E302FB5AA29D88F7 | gpg --import 2>>/var/log/spacelift/error.log


### PR DESCRIPTION
## Description of the change

I've updated the startup script to check whether it's connecting to the MQTT broker for our FedRAMP environment. If so it downloads the FedRAMP-specific version of the launcher.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
