### PR TITLE
chore: mark the solutions engineering team as the repo owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @spacelift-io/solutions-engineering


### PR DESCRIPTION
## Description of the change

I realised that this repo was missing the CODEOWNERS file.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
