### PR TITLE
Change FedRAMP URL to fedramp.spacelift.io

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.1.0
+module_version: 1.1.1
 
 tests:
   - name: System-assigned identity

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
 }
 
 module "azure-worker" {
-  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v1.1.0"
+  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v1.1.1"
 
   admin_password = "Super Secret Password!"
 

--- a/vmss.tf
+++ b/vmss.tf
@@ -34,7 +34,7 @@ if [[ -n "$SPACELIFT_TOKEN" ]]; then
   decoded_token=$(echo "$SPACELIFT_TOKEN" | base64 -d 2>/dev/null || echo "")
   if [[ -n "$decoded_token" ]]; then
     broker_endpoint=$(echo "$decoded_token" | jq -r '.broker.endpoint' 2>/dev/null || echo "")
-    if [[ "$broker_endpoint" == *".gov.spacelift.io" ]]; then
+    if [[ "$broker_endpoint" == *".fedramp.spacelift.io" ]]; then
       fedrampSuffix="-fedramp"
     fi
   fi


### PR DESCRIPTION
## Description of the change

As we think that will be more future poof.
Our environment runs in non-gov cloud and only FedRAMP moderate. In case we launch a FedRAMP High in the future, that runs in gov-cloud, the current URL could lead to a lot of customer confusion.

CU-869a9w96v

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
