### PR TITLE
feat: make OS disk type configurable, default to Standard SSD

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.0.0
+module_version: 2.1.0
 
 tests:
   - name: System-assigned identity

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,16 @@ variable "non_autoscaled_vmss_instances" {
   default     = 2
 }
 
+variable "os_disk_storage_account_type" {
+  type        = string
+  description = "The storage account type for the OS disk. Standard_LRS (HDD) is being retired by Azure on September 8, 2028."
+  default     = "StandardSSD_LRS"
+  validation {
+    condition     = contains(["Standard_LRS", "StandardSSD_LRS", "Premium_LRS", "StandardSSD_ZRS", "Premium_ZRS"], var.os_disk_storage_account_type)
+    error_message = "The os_disk_storage_account_type must be one of: Standard_LRS, StandardSSD_LRS, Premium_LRS, StandardSSD_ZRS, Premium_ZRS."
+  }
+}
+
 variable "vmss_sku" {
   type        = string
   description = "The VM SKU to use for the VMSS instances."

--- a/vmss.tf
+++ b/vmss.tf
@@ -158,7 +158,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
 
   os_disk {
     caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
+    storage_account_type = var.os_disk_storage_account_type
   }
 
   network_interface {


### PR DESCRIPTION
## Summary

- Make the OS disk storage account type configurable via a new `os_disk_storage_account_type` variable
- Change the default from `Standard_LRS` (HDD) to `StandardSSD_LRS` (Standard SSD)
- Azure is retiring Standard HDD (`Standard_LRS`) on September 8, 2028

## Changes

1. **variables.tf**: Added `os_disk_storage_account_type` variable with input validation restricting values to valid Azure storage account types (`Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS`, `Premium_ZRS`)
2. **vmss.tf**: Replaced hardcoded `Standard_LRS` with `var.os_disk_storage_account_type` in the VMSS OS disk configuration

This is a non-breaking change — existing users who were relying on the default HDD behavior can explicitly set `os_disk_storage_account_type = "Standard_LRS"` to retain it. New deployments will use Standard SSD by default, which is the recommended path forward given the Azure retirement timeline.