### PR TITLE
feat: add autoscaler example with Azure Function scaling

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -5,6 +5,9 @@ tests:
   - name: System-assigned identity
     project_root: examples/system-assigned-identity
 
+  - name: Autoscaler
+    project_root: examples/autoscaler
+
   # This test case is currently disabled because the destroy is failing when trying to delete
   # the KeyVault. It looks like it may be related to this issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/19322
   # - name: Password authentication

--- a/README.md
+++ b/README.md
@@ -9,24 +9,39 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.61.0"
+      version = "=4.42.0"
     }
   }
 }
 
 module "azure-worker" {
-  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v1.1.1"
+  source = "github.com/spacelift-io/terraform-azure-spacelift-workerpool?ref=v2.1.0"
 
-  admin_password = "Super Secret Password!"
+  admin_public_key = var.admin_public_key
 
   configuration = <<-EOT
-    export SPACELIFT_TOKEN="${var.worker_pool_config}"
-    export SPACELIFT_POOL_PRIVATE_KEY="${var.worker_pool_private_key}"
+    export SPACELIFT_TOKEN=${var.worker_pool_config}
+    export SPACELIFT_POOL_PRIVATE_KEY=${var.worker_pool_private_key}
   EOT
 
-  resource_group = var.resource_group # An azurerm_resource_group object - must have `name` and `location` properties
+  resource_group = var.resource_group
   subnet_id      = var.subnet_id
   worker_pool_id = var.worker_pool_id
+
+  autoscaling_configuration = {
+    max_create    = 2
+    max_terminate = 1
+    scale = {
+      min = 1
+      max = 5
+    }
+  }
+
+  spacelift_api_credentials = {
+    api_key_id       = var.spacelift_api_key_id
+    api_key_secret   = var.spacelift_api_key_secret
+    api_key_endpoint = var.spacelift_api_key_endpoint
+  }
 }
 ```
 
@@ -69,6 +84,8 @@ This module automatically uses the FedRAMP worker image for FedRAMP worker pools
 
 The following examples of using the module are available:
 
+- [Autoscaler](./examples/autoscaler/README.md) - creates a worker with the autoscaler enabled,
+  using an Azure Function to automatically scale the VMSS based on queue depth.
 - [Bastion](./examples/bastion/README.md) - creates a worker with a Bastion host for ssh access.
 - [System-Assigned Identity](./examples/system-assigned-identity/README.md) - creates a worker
   with a system-assigned identity.

--- a/autoscaler/function_package/package.sh
+++ b/autoscaler/function_package/package.sh
@@ -54,8 +54,20 @@ cp "$SCRIPT_DIR/host.json" "$PACKAGE_DIR/host.json"
 cp "$SCRIPT_DIR/AutoscalerTimer/function.json" "$PACKAGE_DIR/AutoscalerTimer/function.json"
 
 echo "Creating deployment package..."
-cd "${PACKAGE_DIR}"
-zip -r -q "$OUTPUT_ZIP" ./*
+# Use python to zip the directory since zip cli isnt on spacelift public workers
+python3 -c "
+import zipfile, os, sys
+
+source_dir = sys.argv[1]
+output_zip = sys.argv[2]
+
+with zipfile.ZipFile(output_zip, 'w', zipfile.ZIP_DEFLATED) as z:
+    for root, dirs, files in os.walk(source_dir):
+        for f in files:
+            full_path = os.path.join(root, f)
+            arc_name = os.path.relpath(full_path, source_dir)
+            z.write(full_path, arc_name)
+" "$PACKAGE_DIR" "$OUTPUT_ZIP"
 
 echo "Package created successfully at $OUTPUT_ZIP"
 echo "Package size: $(du -h "$OUTPUT_ZIP" | cut -f1)"

--- a/examples/autoscaler/README.md
+++ b/examples/autoscaler/README.md
@@ -1,0 +1,52 @@
+# Private Worker with Autoscaler
+
+This example shows how to provision a Spacelift private worker using an Azure VMSS with the
+autoscaler enabled. The autoscaler deploys an Azure Function that monitors the Spacelift worker
+pool queue and automatically scales the VMSS up and down based on demand.
+
+## What Gets Created
+
+In addition to the standard worker pool resources (VMSS, VNet, subnet, etc.), the autoscaler
+provisions:
+
+- An **Azure Function App** running the Spacelift autoscaler binary
+- A **Storage Account** for the Function App package
+- An **App Service Plan** (Linux, S1 SKU)
+- An **Application Insights** instance for monitoring
+- A **Key Vault** for storing the Spacelift API key secret (or uses an existing one)
+- **RBAC role assignments** granting the Function App permission to scale the VMSS
+
+## Prerequisites
+
+You need a [Spacelift API key](https://docs.spacelift.io/integrations/api#spacelift-api-key-token)
+with permissions to read worker pool information. The autoscaler uses this to query the queue
+depth and decide when to scale.
+
+## Usage
+
+This example uses placeholder/dummy values for all secrets (SSH keys, worker pool credentials,
+API keys) so it can be used for testing without real Spacelift credentials. Initialize and apply:
+
+```shell
+terraform init
+terraform apply
+```
+
+> **Note:** In production, replace the hardcoded placeholder values in `main.tf` with real
+> credentials from your Spacelift account.
+
+## Autoscaler Configuration
+
+The `autoscaling_configuration` block in `main.tf` controls the autoscaler behavior:
+
+| Parameter           | Default        | Description                                                      |
+|---------------------|----------------|------------------------------------------------------------------|
+| `max_create`        | `1`            | Maximum instances to create in a single autoscaler run           |
+| `max_terminate`     | `1`            | Maximum instances to terminate in a single autoscaler run        |
+| `scale.min`         | —              | Minimum number of VMSS instances                                 |
+| `scale.max`         | `5`            | Maximum number of VMSS instances                                 |
+| `schedule_expression` | `0 */5 * * * *` | Azure Functions cron expression for how often the autoscaler runs |
+| `version`           | `latest`       | Version of the autoscaler binary to deploy                       |
+| `architecture`      | `amd64`        | Instruction set architecture (`amd64` or `arm64`)                |
+| `key_vault_id`      | `null`         | Existing Key Vault ID (creates a new one if null)                |
+| `scale_down_delay`  | `0`            | Minutes a worker must be registered before eligible for termination |

--- a/examples/autoscaler/data.tf
+++ b/examples/autoscaler/data.tf
@@ -1,0 +1,1 @@
+data "azurerm_subscription" "primary" {}

--- a/examples/autoscaler/group.tf
+++ b/examples/autoscaler/group.tf
@@ -1,0 +1,8 @@
+resource "random_pet" "this" {}
+
+resource "azurerm_resource_group" "this" {
+  name     = "rg-${var.application}-${random_pet.this.id}-${var.env}"
+  location = var.location
+
+  tags = local.tags
+}

--- a/examples/autoscaler/main.tf
+++ b/examples/autoscaler/main.tf
@@ -1,0 +1,79 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=4.42.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "=3.1.0"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "=4.0.6"
+    }
+  }
+}
+
+resource "tls_private_key" "spacelift_api" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "tls_private_key" "admin_ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "random_string" "worker_pool_id" {
+  length = 26
+  number = true
+  # Spacelift worker pool IDs use uppercase + digits, excluding I, L, O, U
+  special          = true
+  override_special = "ABCDEFGHJKMNPQRSTVWXYZ"
+  lower            = false
+  upper            = false
+}
+
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+module "azure-worker" {
+  source = "../../"
+
+  admin_username   = var.admin_username
+  admin_public_key = base64encode(tls_private_key.admin_ssh.public_key_openssh)
+
+  configuration = <<-EOT
+    export SPACELIFT_TOKEN="<token-here>"
+    export SPACELIFT_POOL_PRIVATE_KEY="<private-key-here>"
+  EOT
+
+  resource_group = azurerm_resource_group.this
+  subnet_id      = azurerm_subnet.worker.id
+
+  identity_type = "SystemAssigned"
+
+  worker_pool_id = random_string.worker_pool_id.id
+  name_prefix    = "sp5ft-autoscaler"
+  tags           = local.tags
+
+  autoscaling_configuration = {
+    max_create    = 2
+    max_terminate = 1
+    scale = {
+      min = 1
+      max = 5
+    }
+  }
+
+  spacelift_api_credentials = {
+    api_key_id       = "placeholder-api-key-id"
+    api_key_secret   = "placholder-api-key-secret"
+    api_key_endpoint = "https://spacelift-solutions.app.spacelift.io/graphql"
+  }
+}

--- a/examples/autoscaler/network.tf
+++ b/examples/autoscaler/network.tf
@@ -1,0 +1,15 @@
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+}
+
+# Create a subnet for our workers
+resource "azurerm_subnet" "worker" {
+  name                 = "worker"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = ["10.0.2.0/24"]
+}

--- a/examples/autoscaler/variables.tf
+++ b/examples/autoscaler/variables.tf
@@ -1,0 +1,29 @@
+locals {
+  tags = {
+    application = var.application
+    env         = var.env
+    region      = var.location
+  }
+}
+
+variable "admin_username" {
+  type    = string
+  default = "spacelift"
+}
+
+variable "application" {
+  type    = string
+  default = "sp5ft-autoscaler"
+}
+
+variable "env" {
+  type    = string
+  default = "test"
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}
+
+


### PR DESCRIPTION
## Summary

- Added a complete autoscaler example demonstrating how to deploy a Spacelift private worker with automatic VMSS scaling via Azure Functions
- Updated the root README with the current module version (v2.1.0), azurerm v4.42.0, and autoscaling configuration
- Added a Spacelift test case for the new example

## Changes

1. **examples/autoscaler/**: New Terraform example with full infrastructure — VMSS worker, VNet, subnet, resource group, and autoscaler configuration using placeholder credentials for testing
2. **README.md**: Bumped azurerm provider to v4.42.0, module ref to v2.1.0, switched from password to SSH key auth, added `autoscaling_configuration` and `spacelift_api_credentials` blocks to the usage example, and linked the new autoscaler example
3. **.spacelift/config.yml**: Added the `Autoscaler` test case pointing to `examples/autoscaler`